### PR TITLE
Update package main to stay consistent with README

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "beaver-logger",
   "version": "1.0.10",
   "description": "Client side logger.",
-  "main": "server/index.js",
+  "main": "dist/beaver-logger.js",
   "scripts": {
     "test": "gulp lint"
   },


### PR DESCRIPTION
The README currently states that the client library can be included as follows:
```
let $logger = require('beaver-logger');
```


The `main` attribute in package.json points to `server/index.js`, so client requires with webpack/browserify currently get the server bundle.

As per the readme, the server-side can still be required with `require('beaver-logger/server')`.