### PR TITLE
Support for jsc

### DIFF
--- a/client/util.js
+++ b/client/util.js
@@ -105,11 +105,14 @@ export function promiseDebounce(method, interval) {
 }
 
 export let windowReady = new ZalgoPromise(resolve => {
-    if (document.readyState === 'complete') {
+    // guard document, and window.addEventListener for JSC (react-native)
+    if (typeof(document) !== 'undefined' && document.readyState === 'complete') {
         resolve();
     }
-
-    window.addEventListener('load', resolve);
+    
+    if(window.addEventListener) {
+        window.addEventListener ('load', resolve);
+    }
 });
 
 export function safeInterval(method, time) {

--- a/test/test.js
+++ b/test/test.js
@@ -19,8 +19,8 @@ describe('xcomponent tests', function() {
         var logEndpoint = $mockEndpoint.register({
             method: 'POST',
             uri: '/test/api/log',
-            handler: function(data) {
-                var hasLog = data.events.some(event => event.event === 'hello_world' && event.level === 'info');
+            handler: function(req) {
+                var hasLog = req.data.events.some(event => event.event === 'hello_world' && event.level === 'info');
                 assert.isTrue(hasLog, 'Expected posted payload to contain logged log')
             }
         });


### PR DESCRIPTION
Issue. The JSC doesn't have a `document` object, and it's `window` object is limited, and doesn't have event listening.

Fix. Instead of filling these in the environment, this change prevents window attachments for now. Something more robust could be introduced to capture more environment items automagically. But for now this allows `beaver-logger` to be used within the JSC for `$logger.info` and `$logger.track` calls.

Also looks like the returned object from `sync-browser-mocks` attaches the `data` to a parent object, I make the change below to be `req.data` so that tests can run appropriately. Completely willing to drop that from PR if there is a better solution. 

Thanks!