### PR TITLE
Fix syntax highlighting typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Configuration
 Full configuration options:
 
 ```javascript
-```javascript
 var $logger = beaver.Logger({
 
     // Url to send logs to


### PR DESCRIPTION
A fix for a syntax highlighting typo in the `README.md` file.