### PR TITLE
Ensure window.location is defined

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -102,7 +102,8 @@ export function Logger({ url, prefix, logLevel = DEFAULT_LOG_LEVEL, transport = 
 
     function immediateFlush() : ZalgoPromise<void> {
         return ZalgoPromise.try(() => {
-            if (!isBrowser() || window.location.protocol === PROTOCOL.FILE) {
+            if (!isBrowser() ||
+              ("undefined" != typeof window.location && window.location.protocol === PROTOCOL.FILE)) {
                 return;
             }
 


### PR DESCRIPTION
React Native has a global 'window' object but it does not have a location field.
This diff checks for window.location before trying to access window.location.protocol