### PR TITLE
fix/sendBeacon

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -57,7 +57,11 @@ function httpTransport({ url, method, headers, json, enableSendBeacon = false } 
     if (window && window.navigator.sendBeacon && !hasHeaders && enableSendBeacon && window.Blob) {
         return new ZalgoPromise(resolve => {
             const blob = new Blob([ JSON.stringify(json) ], { type: 'application/json' });
-            resolve(window.navigator.sendBeacon(url, blob));
+            try {
+                resolve(window.navigator.sendBeacon(url, blob));
+            } catch (e) {
+                return request({ url, method, headers, json }).then(noop);
+            }
         });
     } else {
         return request({ url, method, headers, json }).then(noop);


### PR DESCRIPTION
Google has disabled a feature of `sendBeacon` due to a security concern and is now throwing an error when it occurs.  We need to catch the error and fallback to request.
https://www.chromestatus.com/feature/5654267444592640#details