### PR TITLE
Revert "use new kraken org prefix for cross-domain-utils"

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "sync-browser-mocks": "^1.0.44"
   },
   "dependencies": {
-    "@krakenjs/cross-domain-utils": "^3.0.2",
     "belter": "^1.0.17",
+    "cross-domain-utils": "^2.0.36",
     "zalgo-promise": "^1.0.26"
   }
 }

--- a/src/http.js
+++ b/src/http.js
@@ -2,7 +2,7 @@
 
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { request, noop } from 'belter/src';
-import { isSameDomain, assertSameDomain, type CrossDomainWindowType } from '@krakenjs/cross-domain-utils/src';
+import { isSameDomain, assertSameDomain, type CrossDomainWindowType } from 'cross-domain-utils/src';
 
 import { canUseSendBeacon, isAmplitude, sendBeacon } from './util';
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { type SameDomainWindowType } from '@krakenjs/cross-domain-utils/src';
+import { type SameDomainWindowType } from 'cross-domain-utils/src';
 
 import { AMPLITUDE_URL } from './config';
 import type { Payload } from './types';


### PR DESCRIPTION
Reverts krakenjs/beaver-logger#53