### PR TITLE
add histogram to metrics for logger

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -23,6 +23,7 @@ import type {
   Payload,
   MetricPayloadCounter,
   MetricPayloadGauge,
+  MetricPayloadHistogram,
 } from "./types";
 
 export type LoggerOptions = {|
@@ -58,6 +59,7 @@ export type LoggerType = {|
   metric: LogMetric,
   metricCounter: (payload: MetricPayloadCounter) => LoggerType,
   metricGauge: (payload: MetricPayloadGauge) => LoggerType,
+  metricHistogram: (payload: MetricPayloadHistogram) => LoggerType,
 
   flush: () => ZalgoPromise<void>,
   immediateFlush: () => ZalgoPromise<void>,
@@ -331,6 +333,16 @@ export function Logger({
     });
   }
 
+  function metricHistogram(metricPayload: MetricPayloadHistogram): LoggerType {
+    return metric({
+      metricNamespace: metricPayload.namespace,
+      metricEventName: metricPayload.event,
+      metricValue: metricPayload.value,
+      metricType: "histogram",
+      dimensions: metricPayload.dimensions,
+    });
+  }
+
   function setTransport(newTransport: Transport): LoggerType {
     transport = newTransport;
     return logger; // eslint-disable-line no-use-before-define
@@ -391,6 +403,7 @@ export function Logger({
     metric,
     metricCounter,
     metricGauge,
+    metricHistogram,
     flush,
     immediateFlush,
     addPayloadBuilder,

--- a/src/logger.test.js
+++ b/src/logger.test.js
@@ -372,6 +372,49 @@ describe("metricGauge", () => {
   });
 });
 
+describe("metricHistogram", () => {
+  test("adds metrics of histogram type", () => {
+    const testLogger = initLogger();
+
+    testLogger.metricHistogram({
+      namespace: "namespace",
+      event: "load",
+      value: 100,
+      dimensions: {
+        one: "1",
+      },
+    });
+
+    expect(getLoggerBuffer(testLogger).metrics[0]).toEqual({
+      metricNamespace: "namespace",
+      metricEventName: "load",
+      metricValue: 100,
+      metricType: "histogram",
+      dimensions: {
+        one: "1",
+      },
+    });
+  });
+
+  test("uses metric namespace prefix", () => {
+    const testLogger = initLogger({
+      metricNamespacePrefix: "prefix",
+    });
+
+    testLogger.metricHistogram({
+      namespace: "namespace",
+      event: "load",
+      value: 100,
+    });
+
+    expect(getLoggerBuffer(testLogger).metrics[0]).toEqual(
+      expect.objectContaining({
+        metricNamespace: "prefix.namespace",
+      })
+    );
+  });
+});
+
 describe("addMetricDimensionBuilder", () => {
   test("adds dimensions from builder", () => {
     const testLogger = initLogger();

--- a/src/types.js
+++ b/src/types.js
@@ -6,7 +6,7 @@ export type MetricPayload = {|
   metricNamespace: string, // the name of the metric that's used for charting / finding in signalFx
   metricEventName: string, // assigned to event_name dimension in signalFx
   metricValue?: number, // in most cases this will be 1 if we want to count 1 instance of an event happening.
-  metricType?: "counter" | "gauge", // We support these types of metrics. Defaults to counter.
+  metricType?: "counter" | "gauge" | "histogram", // We support these types of metrics. Defaults to counter.
   /**
    * For proper usage & best practices guidance around dimensions please read: -------------------->
    * - https://engineering.paypalcorp.com/confluence/pages/viewpage.action?pageId=981633893
@@ -28,6 +28,18 @@ export type MetricPayloadCounter = {|
 |};
 
 export type MetricPayloadGauge = {|
+  namespace: string, // the name of the metric that's used for charting / finding in signalFx
+  event: string, // assigned to event_name dimension in signalFx
+  value: number, // in most cases this will be 1 if we want to count 1 instance of an event happening.
+  /**
+   * For proper usage & best practices guidance around dimensions please read: -------------------->
+   * - https://engineering.paypalcorp.com/confluence/pages/viewpage.action?pageId=981633893
+   * - https://engineering.paypalcorp.com/confluence/display/Checkout/Checkout+Observability+Overview
+   */
+  dimensions?: { [string]: mixed },
+|};
+
+export type MetricPayloadHistogram = {|
   namespace: string, // the name of the metric that's used for charting / finding in signalFx
   event: string, // assigned to event_name dimension in signalFx
   value: number, // in most cases this will be 1 if we want to count 1 instance of an event happening.


### PR DESCRIPTION
The checkout team did the work on the backend for our logger endpoint to accept histogram metrics. This allows us to create and send them.

Here is more information on histograms if you are interested: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram